### PR TITLE
fix(webpack-config): support multiple entry points in asset-manifest

### DIFF
--- a/packages/webpack-config/src/FrontlineWebpackConfig.ts
+++ b/packages/webpack-config/src/FrontlineWebpackConfig.ts
@@ -153,9 +153,15 @@ export function FrontlineWebpackConfig(
                             {}
                         );
 
-                        const entrypointFiles = entrypoints.main.filter(
-                            fileName => !fileName.endsWith(".map")
-                        );
+                        const entrypointFiles: {
+                            [key: string]: Array<string>;
+                        } = {};
+
+                        Object.keys(entrypoints).forEach(k => {
+                            entrypointFiles[k] = entrypoints[k].filter(
+                                fileName => !fileName.endsWith(".map")
+                            );
+                        });
 
                         manifest[browserslistEnv].files = manifestFiles;
                         manifest[browserslistEnv].entrypoints = entrypointFiles;


### PR DESCRIPTION
Woopsie daisy - when building the asset-manifest file, I never bothered to test with different type of `entry` definitions. It assumed that we never used named entries (entry map vs. array or single string).