### PR TITLE
Added custom localIdentName for CSS Modules debugging

### DIFF
--- a/packages/scss-config-webpack-plugin/src/config/development.config.ts
+++ b/packages/scss-config-webpack-plugin/src/config/development.config.ts
@@ -67,8 +67,7 @@ export = (options: FrontlineScssWebpackPluginOptions) => ({
                             sourceMap: false,
                             importLoaders: 3,
                             modules: {
-                                localIdentName:
-                                    "[name]__[local]--[hash:base64:5]"
+                                localIdentName: "[path][name]__[local]"
                             }
                         }
                     },

--- a/packages/scss-config-webpack-plugin/src/config/development.config.ts
+++ b/packages/scss-config-webpack-plugin/src/config/development.config.ts
@@ -66,7 +66,10 @@ export = (options: FrontlineScssWebpackPluginOptions) => ({
                         options: {
                             sourceMap: false,
                             importLoaders: 3,
-                            modules: true
+                            modules: {
+                                localIdentName:
+                                    "[name]__[local]--[hash:base64:5]"
+                            }
                         }
                     },
                     {


### PR DESCRIPTION
This makes debugging CSS during development much easier :)
I haven't made the same change in the production config, because some article told me not to.

[DPFRONT-101](https://dis-play.atlassian.net/secure/RapidBoard.jspa?rapidView=35&modal=detail&selectedIssue=DPFRONT-101)

![image](https://user-images.githubusercontent.com/6906782/75345501-1db91500-589d-11ea-879f-6121e984a252.png)
