### PR TITLE
fix(webpack-config): add browserslist env name to chunks and entry filenames in development mode

### DIFF
--- a/packages/webpack-config/src/FrontlineWebpackConfig.ts
+++ b/packages/webpack-config/src/FrontlineWebpackConfig.ts
@@ -45,7 +45,6 @@ export function FrontlineWebpackConfig(
 
     const devServerConfig: WebpackDevServerConfiguration = {
         compress: true,
-        clientLogLevel: "none",
         contentBase: paths.appPublic,
         watchContentBase: true,
         hot: true,
@@ -75,7 +74,8 @@ export function FrontlineWebpackConfig(
         optimization: {
             minimize: isEnvProduction,
             splitChunks: {
-                chunks: "all"
+                chunks: "all",
+                name: false
             },
             runtimeChunk: {
                 // dont generate runtime chunks for CSS entries
@@ -108,11 +108,11 @@ export function FrontlineWebpackConfig(
             // In development, it does not produce real files.
             filename: isEnvProduction
                 ? `static/js/[name].${browserslistEnv}.[contenthash:8].js`
-                : "static/js/[name].js",
+                : `static/js/[name].${browserslistEnv}.js`,
 
             chunkFilename: isEnvProduction
                 ? `static/js/[name].${browserslistEnv}.[contenthash:8].chunk.js`
-                : "static/js/[name].chunk.js",
+                : `static/js/[name].${browserslistEnv}.chunk.js`,
 
             publicPath: publicPath,
 
@@ -222,9 +222,7 @@ export function FrontlineWebpackConfig(
 
         resolve: {
             alias: {
-                ...(isEnvDevelopment
-                    ? { "react-dom": "@hot-loader/react-dom" }
-                    : {})
+                "react-dom": "@hot-loader/react-dom"
             }
         },
 

--- a/packages/webpack-config/test/FrontlineWebpackConfig.test.ts
+++ b/packages/webpack-config/test/FrontlineWebpackConfig.test.ts
@@ -54,7 +54,6 @@ describe("FrontlineWebpackConfig", () => {
 
         expect(webpackConfig.devServer).toEqual({
             compress: true,
-            clientLogLevel: "none",
             contentBase: paths.appPublic,
             watchContentBase: true,
             hot: true,
@@ -141,8 +140,8 @@ describe("FrontlineWebpackConfig inside webpack context", () => {
             });
 
             expect(generatedFiles).toEqual([
-                "./fixtures/dist/static/js/main.chunk.js",
-                "./fixtures/dist/static/js/runtime-main.js"
+                "./fixtures/dist/static/js/main.modern.chunk.js",
+                "./fixtures/dist/static/js/runtime-main.modern.js"
             ]);
 
             done();
@@ -171,8 +170,8 @@ describe("FrontlineWebpackConfig inside webpack context", () => {
             });
 
             expect(generatedFiles).toEqual([
-                "./fixtures/dist/static/js/main.chunk.js",
-                "./fixtures/dist/static/js/runtime-main.js"
+                "./fixtures/dist/static/js/main.modern.chunk.js",
+                "./fixtures/dist/static/js/runtime-main.modern.js"
             ]);
 
             done();
@@ -206,10 +205,10 @@ describe("FrontlineWebpackConfig inside webpack context", () => {
             });
 
             expect(generatedFiles).toEqual([
-                "./fixtures/dist/static/js/namedIndex.chunk.js",
-                "./fixtures/dist/static/js/namedSecond.chunk.js",
-                "./fixtures/dist/static/js/runtime-namedIndex.js",
-                "./fixtures/dist/static/js/runtime-namedSecond.js"
+                "./fixtures/dist/static/js/namedIndex.modern.chunk.js",
+                "./fixtures/dist/static/js/namedSecond.modern.chunk.js",
+                "./fixtures/dist/static/js/runtime-namedIndex.modern.js",
+                "./fixtures/dist/static/js/runtime-namedSecond.modern.js"
             ]);
 
             done();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/akqa-frontline/frontline/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?
In development mode, `filename` and `chunkFilename` did not have the `browserslistEnv` name set in their filename - i believe this led to "race conditions" when running in development mode.

We are, which is probably not even a good idea, using the module/no-module pattern in development mode - but if both legacy and modern bundles have the same filename - at some point this will become and issue because of how hashes are generated based on file contents.

Ie. you have a legacy runtime, that tries to load a module - the module is actually a modern version.

I believe this is what have led to weird HMR / LiveReload behavior in webpack-dev-server.

Issue: N/A

## What is the new behavior?

Sets the browserslistEnv name in files generated by webpack - even for development env.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
