### PR TITLE
improvement(js-config-webpack-plugin): add react-hot-loader dependency - always add react-hot-loader

### DIFF
--- a/packages/js-config-webpack-plugin/package-lock.json
+++ b/packages/js-config-webpack-plugin/package-lock.json
@@ -3507,6 +3507,11 @@
 				}
 			}
 		},
+		"dom-walk": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -4940,8 +4945,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fb-watchman": {
 			"version": "2.0.1",
@@ -5638,6 +5642,15 @@
 				}
 			}
 		},
+		"global": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+			"integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+			"requires": {
+				"min-document": "^2.19.0",
+				"process": "^0.11.10"
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -5743,6 +5756,14 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"requires": {
+				"react-is": "^16.7.0"
 			}
 		},
 		"hosted-git-info": {
@@ -7259,6 +7280,14 @@
 				"mime-db": "1.43.0"
 			}
 		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "^0.1.0"
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7974,7 +8003,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -8101,11 +8129,37 @@
 				"scheduler": "^0.18.0"
 			}
 		},
+		"react-hot-loader": {
+			"version": "4.12.19",
+			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.19.tgz",
+			"integrity": "sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==",
+			"requires": {
+				"fast-levenshtein": "^2.0.6",
+				"global": "^4.3.0",
+				"hoist-non-react-statics": "^3.3.0",
+				"loader-utils": "^1.1.0",
+				"prop-types": "^15.6.1",
+				"react-lifecycles-compat": "^3.0.4",
+				"shallowequal": "^1.1.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+				}
+			}
+		},
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-			"dev": true
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+		},
+		"react-lifecycles-compat": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -8531,6 +8585,11 @@
 					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
 				}
 			}
+		},
+		"shallowequal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",

--- a/packages/js-config-webpack-plugin/package.json
+++ b/packages/js-config-webpack-plugin/package.json
@@ -32,6 +32,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "browserslist": "4.7.3",
     "core-js": "3.4.1",
+    "react-hot-loader": "4.12.19",
     "terser-webpack-plugin": "2.2.1",
     "webpack": "4.41.2"
   },

--- a/packages/js-config-webpack-plugin/src/config/FrontlineBabelConfig.ts
+++ b/packages/js-config-webpack-plugin/src/config/FrontlineBabelConfig.ts
@@ -54,7 +54,7 @@ export function FrontlineBabelConfig() {
                     ]
                 ],
                 plugins: [
-                    isEnvDevelopment && "react-hot-loader/babel",
+                    "react-hot-loader/babel",
                     require("@babel/plugin-syntax-dynamic-import").default,
                     require("@babel/plugin-proposal-nullish-coalescing-operator")
                         .default,
@@ -99,7 +99,7 @@ export function FrontlineBabelConfig() {
                     ]
                 ],
                 plugins: [
-                    isEnvDevelopment && "react-hot-loader/babel",
+                    "react-hot-loader/babel",
                     require("@babel/plugin-syntax-dynamic-import").default,
                     require("@babel/plugin-proposal-nullish-coalescing-operator")
                         .default,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/akqa-frontline/frontline/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?
We use react-hot-loader's babel plugin in our js webpack configuration, but we did not list it as a dependency. Luckily, we also use it in our webpack-config package so it has been installed anyways in peoples projects. 

Issue: N/A

## What is the new behavior?

This PR makes sure that even if you just use our JS setup you have the dependencies you need :)

This also simplifies part of the babel config by always loading react-hot-loader/babel plugin - this is in line with the documentation of react-hot-loader.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
